### PR TITLE
Import settings from django.conf.settings

### DIFF
--- a/mis/urls.py
+++ b/mis/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url, static
 from django.contrib import admin
-from mis import settings
+from django.conf import settings
 import workflow.views
 import invent.urls
 import basedata.urls


### PR DESCRIPTION
Importing from `django.conf.settings` is preferable [read more](https://django.doctor/advice/C4006)

I found this problem during auditing your codebase. [Read the full report](https://django.doctor/zhuinfo/Django-ERP)